### PR TITLE
Beacons now have a consistent ID creation

### DIFF
--- a/Beacon/app/src/main/java/com/comp3004/beacon/DatabaseListeners/PublicBeaconListener.java
+++ b/Beacon/app/src/main/java/com/comp3004/beacon/DatabaseListeners/PublicBeaconListener.java
@@ -5,12 +5,16 @@ import android.database.CursorIndexOutOfBoundsException;
 import com.comp3004.beacon.Networking.PublicBeaconHandler;
 import com.comp3004.beacon.User.Beacon;
 import com.comp3004.beacon.User.BeaconUser;
+import com.comp3004.beacon.User.CurrentUserPublicBeaconHandler;
 import com.comp3004.beacon.User.PrivateBeacon;
 import com.comp3004.beacon.User.CurrentBeaconUser;
 import com.comp3004.beacon.User.PublicBeacon;
 import com.google.firebase.database.ChildEventListener;
 import com.google.firebase.database.DataSnapshot;
 import com.google.firebase.database.DatabaseError;
+
+import java.util.Arrays;
+import java.util.List;
 
 /**
  * Created by julianclayton on 16-10-19.
@@ -19,6 +23,14 @@ public class PublicBeaconListener implements ChildEventListener {
     @Override
     public void onChildAdded(DataSnapshot dataSnapshot, String s) {
         PublicBeacon publicBeacon = dataSnapshot.getValue(PublicBeacon.class);
+
+        if (getUserId(dataSnapshot.getKey()).equals(CurrentBeaconUser.getInstance().getUserId())) {
+            CurrentUserPublicBeaconHandler currentUserPublicBeaconHandler = CurrentUserPublicBeaconHandler.getInstance();
+            currentUserPublicBeaconHandler.setHasPublicBeacon(true);
+            currentUserPublicBeaconHandler.setPublicBeacon(publicBeacon);
+            currentUserPublicBeaconHandler.setKey(dataSnapshot.getKey());
+        }
+        publicBeacon.setBeaconId(dataSnapshot.getKey());
         if (!publicBeacon.getFromUserId().equals(CurrentBeaconUser.getInstance().getUserId())) {
             PublicBeaconHandler.getInstance().addBeacon(dataSnapshot.getKey(), publicBeacon);
         }
@@ -43,7 +55,7 @@ public class PublicBeaconListener implements ChildEventListener {
     @Override
     public void onChildRemoved(DataSnapshot dataSnapshot) {
         PublicBeacon publicBeacon = dataSnapshot.getValue(PublicBeacon.class);
-        PublicBeaconHandler.getInstance().removeBeacon(publicBeacon.getBeaconId());
+        PublicBeaconHandler.getInstance().removeBeacon(dataSnapshot.getKey());
     }
 
     @Override
@@ -54,5 +66,12 @@ public class PublicBeaconListener implements ChildEventListener {
     @Override
     public void onCancelled(DatabaseError databaseError) {
 
+    }
+
+    public String getUserId(String id) {
+
+        List<String> ids = Arrays.asList(id.split("_"));
+        String id1 = ids.get(0);
+        return id1;
     }
 }

--- a/Beacon/app/src/main/java/com/comp3004/beacon/Networking/MessageSenderHandler.java
+++ b/Beacon/app/src/main/java/com/comp3004/beacon/Networking/MessageSenderHandler.java
@@ -6,11 +6,13 @@ import android.support.annotation.NonNull;
 
 import com.comp3004.beacon.FirebaseServices.DatabaseManager;
 import com.comp3004.beacon.User.CurrentBeaconUser;
+import com.comp3004.beacon.User.CurrentUserPublicBeaconHandler;
 import com.comp3004.beacon.User.PrivateBeacon;
 import com.comp3004.beacon.User.PublicBeacon;
 import com.google.android.gms.maps.model.LatLng;
 import com.google.android.gms.tasks.OnFailureListener;
 import com.google.android.gms.tasks.OnSuccessListener;
+import com.google.firebase.database.DatabaseReference;
 import com.google.firebase.database.FirebaseDatabase;
 import com.google.firebase.storage.FirebaseStorage;
 import com.google.firebase.storage.StorageReference;
@@ -57,15 +59,16 @@ public class MessageSenderHandler {
         FirebaseDatabase.getInstance().getReference().child(MessageTypes.BEACON_REQUEST_MESSAGE).push().setValue(notification);
 
         BeaconInvitationMessage beaconInvitationMessage = new BeaconInvitationMessage(senderId, CurrentBeaconUser.getInstance().getUserId(), beaconMessage, Double.toString(current.getLatitude()), Double.toString(current.getLongitude()), false);
+        String beaconId = currentBeaconUser.getUserId() + "_" + System.currentTimeMillis() + "_private";
+        FirebaseDatabase.getInstance().getReference().child("/" + senderId + "_beaconRequests/" + beaconId).setValue(beaconInvitationMessage);
 
-        FirebaseDatabase.getInstance().getReference().child("/" + senderId + "_beaconRequests").push().setValue(beaconInvitationMessage);
     }
 
     //Method allows users to follow and track public beacons
     public void followBeacon(PublicBeacon publicBeacon) {
 
         PrivateBeacon privateBeacon = new PrivateBeacon(publicBeacon);
-        FirebaseDatabase.getInstance().getReference().child("/" + CurrentBeaconUser.getInstance().getUserId() + "_beaconRequests").push().setValue(privateBeacon);
+        FirebaseDatabase.getInstance().getReference().child("/" + CurrentBeaconUser.getInstance().getUserId() + "_beaconRequests").child(publicBeacon.getBeaconId()).setValue(privateBeacon);
 
     }
 
@@ -81,10 +84,13 @@ public class MessageSenderHandler {
 
         PublicBeacon publicBeacon = new PublicBeacon(currentBeaconUser.getUserId(), currentBeaconUser.getDisplayName(), Double.toString(latLng.latitude), Double.toString(latLng.longitude));
 
-        FirebaseDatabase.getInstance().getReference().child(MessageTypes.PUBLIC_BEACON + "/").child(currentBeaconUser.getUserId()).setValue(publicBeacon);
-
-
-
+        if (CurrentUserPublicBeaconHandler.getInstance().isHasPublicBeacon()) {
+            CurrentUserPublicBeaconHandler currentUserPublicBeaconHandler = CurrentUserPublicBeaconHandler.getInstance();
+            FirebaseDatabase.getInstance().getReference().child(MessageTypes.PUBLIC_BEACON + "/" + currentUserPublicBeaconHandler.getKey()).setValue(publicBeacon);
+        }
+        else { //create new entry
+            FirebaseDatabase.getInstance().getReference().child(MessageTypes.PUBLIC_BEACON + "/" + currentBeaconUser.getUserId() + "_" + System.currentTimeMillis()).setValue(publicBeacon);
+        }
     }
 
     public void sendMessage(String toUserId, String message) {
@@ -132,6 +138,5 @@ public class MessageSenderHandler {
 
             }
         });
-
     }
 }

--- a/Beacon/app/src/main/java/com/comp3004/beacon/User/CurrentUserPublicBeaconHandler.java
+++ b/Beacon/app/src/main/java/com/comp3004/beacon/User/CurrentUserPublicBeaconHandler.java
@@ -1,0 +1,53 @@
+package com.comp3004.beacon.User;
+
+/**
+ * Created by julianclayton on 2016-11-05.
+ */
+public class CurrentUserPublicBeaconHandler {
+
+    private static CurrentUserPublicBeaconHandler currentUserPublicBeaconHandler;
+    private  boolean hasPublicBeacon;
+    private PublicBeacon publicBeacon;
+
+    private String key;
+
+    public CurrentUserPublicBeaconHandler() {
+        publicBeacon = null;
+    }
+
+    public static CurrentUserPublicBeaconHandler getInstance() {
+        if (currentUserPublicBeaconHandler == null) {
+            currentUserPublicBeaconHandler = new CurrentUserPublicBeaconHandler();
+        }
+        return currentUserPublicBeaconHandler;
+    }
+
+
+
+    public boolean isHasPublicBeacon() {
+        return hasPublicBeacon;
+    }
+
+    public void setHasPublicBeacon(boolean hasPublicBeacon) {
+        this.hasPublicBeacon = hasPublicBeacon;
+    }
+
+    public  PublicBeacon getPublicBeacon() {
+        return publicBeacon;
+    }
+
+    public void setPublicBeacon(PublicBeacon publicBeacon) {
+        this.publicBeacon = publicBeacon;
+    }
+    public String getKey() {
+        return key;
+    }
+
+    public void setKey(String key) {
+        this.key = key;
+    }
+
+
+
+
+}


### PR DESCRIPTION
When a public beacon is created the ID has the format:
{SENDER_BEACON_ID}_{CURRENT_TIME_MILLIS}

When a private beacon is sent:
 {SENDER_BEACON_ID}_{CURRENT_TIME_MILLIS}_private 

This will allow us to keep track of who sent what beacon and what type more quickly 